### PR TITLE
fix custom theme by ignoring static rendered page.query

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -13,7 +13,7 @@
 		const validAccents = ['red', 'yellow', 'green', 'blue', 'indigo', 'purple', 'pink', 'none'];
 		const validSizes = ['small', 'normal'];
 
-		const query = prerendering ? page.query : new URLSearchParams(location.search);
+		const query = new URLSearchParams(prerendering ? '' : location.search);
 
 		if (query.has('theme')) {
 			const _theme = query.get('theme');

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,5 +1,6 @@
 <script context="module" lang="ts">
 	import { languageNames } from '$lib/Lang';
+	import { prerendering } from '$app/env';
 	import type { Load } from '@sveltejs/kit';
 
 	export const load: Load = async ({ page }) => {
@@ -12,26 +13,28 @@
 		const validAccents = ['red', 'yellow', 'green', 'blue', 'indigo', 'purple', 'pink', 'none'];
 		const validSizes = ['small', 'normal'];
 
-		if (page.query.has('theme')) {
-			const _theme = page.query.get('theme');
+		const query = prerendering ? page.query : new URLSearchParams(location.search);
+
+		if (query.has('theme')) {
+			const _theme = query.get('theme');
 			if (validThemes.includes(_theme)) {
 				theme = _theme;
 			}
 		}
-		if (page.query.has('accent')) {
-			const _accent = page.query.get('accent');
+		if (query.has('accent')) {
+			const _accent = query.get('accent');
 			if (validAccents.includes(_accent)) {
 				accent = _accent;
 			}
 		}
-		if (page.query.has('size')) {
-			const _size = page.query.get('size');
+		if (query.has('size')) {
+			const _size = query.get('size');
 			if (validSizes.includes(_size)) {
 				size = _size;
 			}
 		}
-		if (page.query.has('lang')) {
-			const _lang = page.query.get('lang');
+		if (query.has('lang')) {
+			const _lang = query.get('lang');
 			if (languageNames.includes(_lang)) {
 				lang = _lang;
 			}


### PR DESCRIPTION
by default, static renders render with the light theme.

as detailed in https://github.com/sveltejs/kit/issues/669 static renders mean page.query is empty, thus any query string params don't work.

this change detects if the page is getting prerendered, and if it isn't, it uses the actual query from the browser

pros:
* theme/lang/accent/size works now

cons:
* this is a hack
* flash caused by colour transitions/re-rendering the page

if you still want correct static renders, the only way to do that would be to not use query params and instead generate 224 (heh.) different static bundles, e.g.

`/[theme]/[size]/[accent]/[language]/index.html`

with this patch: https://are-we-there-yet-pi.vercel.app/?theme=dark&accent=red&size=normal&lang=ru works
currently: https://are-we-there-yet.vercel.app/?theme=dark&accent=red&size=normal&lang=ru no work